### PR TITLE
Added compatibility with Torch 2.0

### DIFF
--- a/model.py
+++ b/model.py
@@ -93,7 +93,8 @@ class FourierUnit(nn.Module):
         x = x.view(-1, x.size()[-1])
 
         ffted = torch.stft(x, self.n_fft, hop_length=self.hop_size, win_length=self.win_size, window=self.hann_window,
-                          center=True, normalized=True, onesided=True, return_complex=False)
+                           center=True, normalized=True, onesided=True, return_complex=True)
+        ffted = torch.view_as_real(ffted)
         ffted = ffted.permute(0, 3, 1, 2).contiguous()  # (BC, 2, n_fft/2+1, T)
         ffted = ffted.view((batch, -1,) + ffted.size()[2:])  # (B, 2C, n_fft/2+1, T)
 
@@ -101,7 +102,7 @@ class FourierUnit(nn.Module):
         ffted = self.conv_layer(ffted)
 
         ffted = ffted.view((-1, 2,) + ffted.size()[2:]).permute(0, 2, 3, 1).contiguous()  # (BC, n_fft/2+1, T, 2)
-
+        ffted = torch.view_as_complex(ffted)
         output = torch.istft(ffted, self.n_fft, hop_length=self.hop_size, win_length=self.win_size, window=self.hann_window,
                           center=True, normalized=True, onesided=True)
         output = output.view(batch, -1, x.size()[-1])

--- a/utils/stft.py
+++ b/utils/stft.py
@@ -19,6 +19,7 @@ class STFTMag(nn.Module):
                           self.nfft,
                           self.hop,
                           window=self.window,
-                          )#return_complex=False)  #[B, F, TT,2]
+                          return_complex=True)  #[B, F, TT,2]
+        stft = torch.view_as_real(stft)
         mag = torch.norm(stft, p=2, dim =-1) #[B, F, TT]
         return mag


### PR DESCRIPTION
I've inserted view as real after setting the return_complex values to true because PyTorch 2.0 deprecates the return_complex into runtime errors.

This allows for use on Mac with cpu. After Sonoma and some PyTorch versions maybe this will also allow for mps, but for now the view_as operators aren't implemented in mps and can't be shifted to cpu fallback.